### PR TITLE
Design improvements to the launcher popup

### DIFF
--- a/declarative/launcher/applicationinfo.cpp
+++ b/declarative/launcher/applicationinfo.cpp
@@ -36,10 +36,7 @@
  */
 
 ApplicationInfoPrivate::ApplicationInfoPrivate(const QString &origAppId, ApplicationInfo *parent)
-    : state(ApplicationInfo::NotRunning)
-    , entry(Q_NULLPTR)
-    , focused(false)
-    , q_ptr(parent)
+        : state(ApplicationInfo::NotRunning), entry(Q_NULLPTR), focused(false), q_ptr(parent)
 {
     appId = origAppId;
     fileName = AppIdMapping::desktopFileName(appId);
@@ -61,7 +58,8 @@ ApplicationInfoPrivate::~ApplicationInfoPrivate()
     entry->deleteLater();
 }
 
-QVariant ApplicationInfoPrivate::value(const QString &group, const QString &key, const QVariant &defaultValue) const
+QVariant ApplicationInfoPrivate::value(const QString &group, const QString &key,
+                                       const QVariant &defaultValue) const
 {
     if (!entry)
         return defaultValue;
@@ -73,7 +71,8 @@ QVariant ApplicationInfoPrivate::value(const QString &group, const QString &key,
     return value;
 }
 
-QVariant ApplicationInfoPrivate::localizedValue(const QString &group, const QString &key, const QVariant &defaultValue) const
+QVariant ApplicationInfoPrivate::localizedValue(const QString &group, const QString &key,
+                                                const QVariant &defaultValue) const
 {
     if (!entry)
         return defaultValue;
@@ -120,8 +119,9 @@ void ApplicationInfoPrivate::retrieveActions()
 
     Q_Q(ApplicationInfo);
 
-    QStringList actionNames = value(QLatin1String("Desktop Entry"),
-                                    QLatin1String("Actions")).toString().split(';', QString::SkipEmptyParts);
+    QStringList actionNames = value(QLatin1String("Desktop Entry"), QLatin1String("Actions"))
+                                      .toString()
+                                      .split(';', QString::SkipEmptyParts);
     Q_FOREACH (const QString &actionName, actionNames) {
         const QString group = QStringLiteral("Desktop Action %1").arg(actionName);
 
@@ -129,11 +129,10 @@ void ApplicationInfoPrivate::retrieveActions()
         if (localizedValue(group, QLatin1String("Name")).toString().isEmpty())
             continue;
 
-        ApplicationAction *action = new ApplicationAction(
-                    localizedValue(group, QLatin1String("Name")).toString(),
-                    localizedValue(group, QLatin1String("Icon")).toString(),
-                    localizedValue(group, QLatin1String("Exec")).toString(),
-                    q);
+        ApplicationAction *action =
+                new ApplicationAction(localizedValue(group, QLatin1String("Name")).toString(),
+                                      localizedValue(group, QLatin1String("Icon")).toString(),
+                                      localizedValue(group, QLatin1String("Exec")).toString(), q);
         actions.append(action);
     }
 }
@@ -143,16 +142,12 @@ void ApplicationInfoPrivate::retrieveActions()
  */
 
 ApplicationInfo::ApplicationInfo(const QString &appId, QObject *parent)
-    : QObject(parent)
-    , d_ptr(new ApplicationInfoPrivate(appId, this))
+        : QObject(parent), d_ptr(new ApplicationInfoPrivate(appId, this))
 {
     qRegisterMetaType<ApplicationInfo *>("ApplicationInfo*");
 }
 
-ApplicationInfo::~ApplicationInfo()
-{
-    delete d_ptr;
-}
+ApplicationInfo::~ApplicationInfo() { delete d_ptr; }
 
 ApplicationInfo::State ApplicationInfo::state() const
 {
@@ -178,23 +173,21 @@ QString ApplicationInfo::fileName() const
 QString ApplicationInfo::name() const
 {
     Q_D(const ApplicationInfo);
-    return d->localizedValue(QLatin1String("Desktop Entry"),
-                             QLatin1String("Name")).toString();
+    return d->localizedValue(QLatin1String("Desktop Entry"), QLatin1String("Name")).toString();
 }
 
 QString ApplicationInfo::comment() const
 {
     Q_D(const ApplicationInfo);
-    return d->localizedValue(QLatin1String("Desktop Entry"),
-                             QLatin1String("Comment")).toString();
+    return d->localizedValue(QLatin1String("Desktop Entry"), QLatin1String("Comment")).toString();
 }
 
 QString ApplicationInfo::iconName() const
 {
     Q_D(const ApplicationInfo);
-    return d->value(QLatin1String("Desktop Entry"),
-                    QLatin1String("Icon"),
-                    QLatin1String("application-octet-stream")).toString();
+    return d->value(QLatin1String("Desktop Entry"), QLatin1String("Icon"),
+                    QLatin1String("application-x-executable"))
+            .toString();
 }
 
 bool ApplicationInfo::isFocused() const

--- a/shell/indicators/LauncherIndicator.qml
+++ b/shell/indicators/LauncherIndicator.qml
@@ -45,6 +45,8 @@ Indicator {
 
         parent: screenView
 
+        modal: true
+
         onAppLaunched: close()
     }
 }

--- a/shell/indicators/LauncherIndicator.qml
+++ b/shell/indicators/LauncherIndicator.qml
@@ -40,8 +40,11 @@ Indicator {
 
     Launcher.LauncherPopOver {
         id: popover
-        x: Units.largeSpacing
-        y: -height - Units.largeSpacing
+        x: (output.availableGeometry.width - width)/2
+        y: (output.availableGeometry.height - height)/2
+
+        parent: screenView
+
         onAppLaunched: close()
     }
 }

--- a/shell/launcher/LauncherGridDelegate.qml
+++ b/shell/launcher/LauncherGridDelegate.qml
@@ -31,47 +31,40 @@ import QtQuick.Controls.Material 2.0
 import Fluid.Controls 1.0
 
 Rectangle {
-    property alias iconSize: icon.width
     property bool hovered: false
 
-    color: hovered ? Material.accent : "transparent"
-    radius: 6
+    color: hovered ? Qt.rgba(0,0,0,0.1) : "transparent"
+    radius: 2
     antialiasing: true
 
-    Image {
+    Behavior on color {
+        ColorAnimation { duration: Units.mediumDuration }
+    }
+
+    Icon {
         id: icon
         anchors {
             horizontalCenter: parent.horizontalCenter
             top: parent.top
-            leftMargin: Units.smallSpacing
-            topMargin: Units.smallSpacing
-            rightMargin: Units.smallSpacing
+            bottom: label.top
+            margins: 2 * Units.smallSpacing
         }
-        height: width
-        sourceSize.width: width
-        sourceSize.height: height
-        source: "image://launcher/" + model.iconName
-        cache: false
-        asynchronous: true
+        width: height
+        name: model.iconName
     }
 
     Label {
         id: label
+
         anchors {
             horizontalCenter: parent.horizontalCenter
-            top: icon.bottom
             bottom: parent.bottom
-            leftMargin: Units.smallSpacing
-            topMargin: Units.smallSpacing
-            rightMargin: Units.smallSpacing
-            bottomMargin: Units.smallSpacing
+            margins: Units.smallSpacing
         }
         text: model.name
         elide: Text.ElideRight
-        wrapMode: Text.WrapAtWordBoundaryOrAnywhere
         textFormat: Text.PlainText
         horizontalAlignment: Text.AlignHCenter
-        width: iconSize * 1.5
-        height: Units.gu(2)
+        width: parent.width - 2 * Units.smallSpacing
     }
 }

--- a/shell/launcher/LauncherGridView.qml
+++ b/shell/launcher/LauncherGridView.qml
@@ -27,12 +27,14 @@
 import QtQuick 2.0
 import QtQml.Models 2.1
 import Fluid.Controls 1.0
+import Fluid.Material 1.0
 import org.hawaiios.launcher 0.1 as CppLauncher
 
 GridView {
-    readonly property int iconSize: Units.iconSizes.large
-    readonly property int numRows: 5
-    readonly property int numColumns: 3
+    id: grid
+
+    readonly property int numRows: 6
+    readonly property int numColumns: 4
     readonly property int numItemsPerPage: numRows * numColumns
     readonly property int numPages: Math.ceil(grid.count / numItemsPerPage)
     property int currentPage: 0
@@ -40,9 +42,8 @@ GridView {
 
     signal appLaunched()
 
-    id: grid
-    cellWidth: (iconSize * 1.5) + (Units.largeSpacing * 2)
-    cellHeight: iconSize + Units.gu(2) + (Units.largeSpacing * 2) + Units.smallSpacing
+    cellWidth: 130
+    cellHeight: cellWidth
     width: cellWidth * numRows
     height: cellHeight * numColumns
     snapMode: GridView.SnapOneRow
@@ -62,19 +63,26 @@ GridView {
                 onAppLaunched: grid.appLaunched()
             }
         }
-        delegate: LauncherGridDelegate {
-            id: delegate
-            iconSize: grid.iconSize
+        delegate: Item {
             width: grid.cellWidth
             height: grid.cellHeight
 
-            MouseArea {
-                anchors.fill: parent
-                acceptedButtons: Qt.LeftButton
-                hoverEnabled: true
-                onEntered: delegate.hovered = true
-                onExited: delegate.hovered = false
-                onClicked: appsModel.trigger(visualModel.modelIndex(index))
+            LauncherGridDelegate {
+                id: delegate
+
+                anchors {
+                    fill: parent
+                    margins: Units.smallSpacing
+                }
+
+                Ripple {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.LeftButton
+                    hoverEnabled: true
+                    onEntered: delegate.hovered = true
+                    onExited: delegate.hovered = false
+                    onClicked: appsModel.trigger(visualModel.modelIndex(index))
+                }
             }
         }
     }
@@ -83,4 +91,3 @@ GridView {
         appsModel.categoryFilter = category;
     }
 }
-

--- a/shell/launcher/LauncherPopOver.qml
+++ b/shell/launcher/LauncherPopOver.qml
@@ -29,12 +29,14 @@ import QtQuick.Layouts 1.0
 import QtQuick.Controls 2.0
 import QtQuick.Controls.Material 2.0
 import Fluid.Controls 1.0
+import Fluid.Material 1.0
 
 Popup {
+    id: launcherPopOver
+
     signal appLaunched()
     signal dismissed()
 
-    id: launcherPopOver
     focus: true
     closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
     implicitWidth: mainLayout.implicitWidth +
@@ -44,115 +46,165 @@ Popup {
                     launcherPopOver.topPadding + launcherPopOver.bottomPadding +
                     launcherPopOver.topMargin + launcherPopOver.bottomMargin
 
-    Material.theme: Material.Dark
+    padding: 0
+    rightPadding: 2
 
-    ColumnLayout {
-        id: mainLayout
-        spacing: Units.smallSpacing
+    Material.theme: Material.Light
+    Material.accent: Material.Blue
 
-        RowLayout {
-            IconButton {
-                id: viewCategoriesButton
-                iconName: "action/view_list"
-                checkable: true
-                checked: false
-                autoExclusive: true
-                onClicked: categories.currentIndex = 0
-            }
+    Rectangle {
+        radius: 2
+        color: "#eee"
+        width: mainLayout.width
+        height: mainLayout.height
 
-            IconButton {
-                id: viewPagedButton
-                iconName: "action/view_module"
-                checkable: true
-                checked: true
-                autoExclusive: true
-                onClicked: categories.currentIndex = 0
-            }
+        ColumnLayout {
+            id: mainLayout
 
-            Item {
-                width: Units.smallSpacing
-            }
+            spacing: 0
 
-            TextField {
-                id: searchText
-                placeholderText: qsTr("Type an application name...")
-                focus: true
-                onTextChanged: grid.query = text
-
+            Rectangle {
                 Layout.fillWidth: true
-            }
+                Layout.preferredHeight: topRow.implicitHeight + 2 * topRow.anchors.margins
 
-            Item {
-                Layout.fillWidth: true
-            }
+                color: "white"
+                radius: 2
 
-            LauncherShutdownActions {
-                id: shutdownActions
+                Item {
+                    width: parent.width
+                    height: parent.height + 20
+                    y: parent.radius
+                    clip: true
 
-                Layout.alignment: Qt.AlignHCenter
-            }
+                    Rectangle {
+                        x: -5
+                        y: -parent.y
+                        width: parent.width - 2 * x
+                        height: parent.parent.height
 
-            Layout.fillWidth: true
-        }
-
-        RowLayout {
-            LauncherCategories {
-                id: categories
-                clip: true
-                width: Units.gu(10)
-                visible: viewCategoriesButton.checked
-                onSelected: grid.filterByCategory(category)
-
-                Layout.fillHeight: true
-            }
-
-            ColumnLayout {
-                LauncherGridView {
-                    id: grid
-                    onAppLaunched: launcherPopOver.appLaunched()
-
-                    MouseArea {
-                        anchors.fill: parent
-                        acceptedButtons: Qt.NoButton
-                        onWheel: {
-                            if (wheel.angleDelta.x > 0 || wheel.angleDelta.y > 0) {
-                                // Go to the next page
-                                if (grid.currentPage < grid.numPages - 1) {
-                                    grid.currentPage++;
-                                    grid.currentIndex = grid.currentPage * grid.numItemsPerPage + 1;
-                                }
-                            } else if (wheel.angleDelta.x < 0 || wheel.angleDelta.y < 0) {
-                                // Go to the next page
-                                if (grid.currentPage > 0) {
-                                    grid.currentPage--;
-                                    grid.currentIndex = grid.currentPage * grid.numItemsPerPage + 1;
-                                }
-                            }
-
-                            wheel.accepted = true;
+                        layer.enabled: true
+                        layer.effect: ElevationEffect {
+                            elevation: 2
                         }
+                    }
+                }
+
+                RowLayout {
+                    id: topRow
+                    anchors {
+                        fill: parent
+                        margins: Units.smallSpacing
+                    }
+
+                    IconButton {
+                        id: viewCategoriesButton
+                        iconName: "action/view_list"
+                        checkable: true
+                        checked: false
+                        autoExclusive: true
+                        onClicked: categories.currentIndex = 0
+                    }
+
+                    IconButton {
+                        id: viewPagedButton
+                        iconName: "action/view_module"
+                        checkable: true
+                        checked: true
+                        autoExclusive: true
+                        onClicked: categories.currentIndex = 0
+                    }
+
+                    Item {
+                        width: Units.smallSpacing
+                    }
+
+                    TextField {
+                        id: searchText
+                        placeholderText: qsTr("Type an application name...")
+                        focus: true
+                        onTextChanged: grid.query = text
+
+                        Layout.fillWidth: true
+                    }
+
+                    Item {
+                        Layout.fillWidth: true
+                    }
+
+                    LauncherShutdownActions {
+                        id: shutdownActions
+
+                        Layout.alignment: Qt.AlignHCenter
                     }
 
                     Layout.fillWidth: true
-                    Layout.fillHeight: true
-                }
-
-                PageIndicator {
-                    id: pageIndicator
-                    count: grid.numPages
-                    currentIndex: grid.currentPage
-                    onCurrentIndexChanged: grid.currentPage = currentIndex
-
-                    Layout.alignment: Qt.AlignHCenter
-                }
-
-                Item {
-                    height: Units.smallSpacing
                 }
             }
 
-            Layout.fillWidth: true
-            Layout.fillHeight: true
+            Item {
+                Layout.preferredWidth: contentRow.implicitWidth + 2 * contentRow.anchors.margins
+                Layout.preferredHeight: contentRow.implicitHeight + 2 * contentRow.anchors.margins
+
+                RowLayout {
+                    id: contentRow
+
+                    anchors {
+                        fill: parent
+                        margins: Units.smallSpacing
+                    }
+
+                    LauncherCategories {
+                        id: categories
+                        clip: true
+                        width: Units.gu(10)
+                        visible: viewCategoriesButton.checked
+                        onSelected: grid.filterByCategory(category)
+
+                        Layout.fillHeight: true
+                    }
+
+                    ColumnLayout {
+                        LauncherGridView {
+                            id: grid
+                            onAppLaunched: launcherPopOver.appLaunched()
+
+                            MouseArea {
+                                anchors.fill: parent
+                                acceptedButtons: Qt.NoButton
+                                onWheel: {
+                                    if (wheel.angleDelta.x > 0 || wheel.angleDelta.y > 0) {
+                                        // Go to the next page
+                                        if (grid.currentPage < grid.numPages - 1) {
+                                            grid.currentPage++;
+                                            grid.currentIndex = grid.currentPage * grid.numItemsPerPage + 1;
+                                        }
+                                    } else if (wheel.angleDelta.x < 0 || wheel.angleDelta.y < 0) {
+                                        // Go to the next page
+                                        if (grid.currentPage > 0) {
+                                            grid.currentPage--;
+                                            grid.currentIndex = grid.currentPage * grid.numItemsPerPage + 1;
+                                        }
+                                    }
+
+                                    wheel.accepted = true;
+                                }
+                            }
+
+                            Layout.fillWidth: true
+                            Layout.fillHeight: true
+                        }
+
+                        PageIndicator {
+                            id: pageIndicator
+                            count: grid.numPages
+                            currentIndex: grid.currentPage
+                            onCurrentIndexChanged: grid.currentPage = currentIndex
+
+                            Layout.alignment: Qt.AlignHCenter
+                        }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Center the launcher, add an extra row + column, use a square launcher item with only one row of text, and make the launchers use a light gray highlight and ripple.

![hawaii_010](https://cloud.githubusercontent.com/assets/3230912/17682571/017b1200-6312-11e6-877a-d8c119db9307.png)
